### PR TITLE
feat: Add support for PNG Export to Playwright module closes #2

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -22,3 +22,7 @@ func NewChromePDFReportExporter(timeout time.Duration, vpHeight, vpWidth int) Re
 func NewPlaywrightPDFReportExporter(timeout time.Duration, vpHeight, vpWidth int) ReportExporter {
 	return pw.NewPdfReportExporter(timeout)
 }
+
+func NewPlaywrightPNGReportExporter(timeout time.Duration, vpHeight, vpWidth int) ReportExporter {
+	return pw.NewPngReportExporter(timeout)
+}

--- a/exporter/playwright/png_report_exporter.go
+++ b/exporter/playwright/png_report_exporter.go
@@ -8,17 +8,17 @@ import (
 	"github.com/playwright-community/playwright-go"
 )
 
-type pdfReportExporter struct {
+type pngReportExporter struct {
 	timeout time.Duration
 	// viewportHeight int
 	// viewportWidth  int
 }
 
-func NewPdfReportExporter(timeout time.Duration) *pdfReportExporter {
-	return &pdfReportExporter{timeout: timeout}
+func NewPngReportExporter(timeout time.Duration) *pngReportExporter {
+	return &pngReportExporter{timeout: timeout}
 }
 
-func (pre *pdfReportExporter) Export(url string, renderedTemplate []byte) ([]byte, *models.PrintOptions, error) {
+func (pre *pngReportExporter) Export(url string, renderedTemplate []byte) ([]byte, *models.PrintOptions, error) {
 
 	pw, err := playwright.Run()
 	if err != nil {
@@ -38,17 +38,19 @@ func (pre *pdfReportExporter) Export(url string, renderedTemplate []byte) ([]byt
 	if err != nil {
 		return nil, nil, err
 	}
+
 	err = page.SetContent(string(renderedTemplate))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	data, err := page.PDF(playwright.PagePdfOptions{
+	data, err := page.Screenshot(playwright.PageScreenshotOptions{
 		// Path: TODO(zikani03): Add option to save file to disk?
+		FullPage:   playwright.Bool(true),
+		Animations: playwright.ScreenshotAnimationsDisabled,
 	})
-
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("could not create screenshot: %v", err)
 	}
 
 	defer browser.Close()

--- a/module.go
+++ b/module.go
@@ -67,7 +67,7 @@ func NewPlaywrightModule(renderTimeout time.Duration, repo repo.TemplateReposito
 
 	engine := engine.NewGolangTemplateEngine()
 	// repo := data.NewFilesystemTemplateRepo(config.TemplatesPath)
-	png := exporter.NewChromePNGReportExporter(realRenderTimeout, viewportHeight, viewportWidth)
+	png := exporter.NewPlaywrightPNGReportExporter(realRenderTimeout, viewportHeight, viewportWidth)
 	pdf := exporter.NewPlaywrightPDFReportExporter(realRenderTimeout, viewportHeight, viewportWidth)
 
 	tmplSrv := service.NewTemplateService(engine, repo)

--- a/service/report_service_impl.go
+++ b/service/report_service_impl.go
@@ -51,8 +51,11 @@ func (rs *reportService) ExportReportPng(reportId string, data interface{}) ([]b
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "failed to build url for pdf export on reportId: %s and data: %+v", reportId, data)
 	}
-
-	png, _, err := rs.png.Export(url, nil) // TODO: replace nil with rendered html
+	html, err := rs.templateService.RenderTemplate(reportId, data)
+	if err != nil {
+		return nil, stacktrace.RootCause(err)
+	}
+	png, _, err := rs.png.Export(url, html)
 	if err != nil {
 		return nil, stacktrace.RootCause(err)
 	}


### PR DESCRIPTION
- Using playwright's Screenshot functionality to export PNGs
- Removed saving to temporary files for both PDF and PNG exporters
- Added function to the exporter.go
- Fixed the Playwright module to use the playwright png exporter instead of the chromedp one