### PR TITLE
feat: Allow Clients to specify Accept: application/zip header on bulk request

### DIFF
--- a/cmd/greypot-server/data.go
+++ b/cmd/greypot-server/data.go
@@ -1,0 +1,16 @@
+package main
+
+import "github.com/nndi-oss/greypot/http/fiber/handlers"
+
+type UploadTemplateRequest struct {
+	Name     string
+	Template string
+	Data     any
+}
+
+type BulkUploadTemplateRequest struct {
+	Name     string
+	Template string
+	Data     any
+	Entries  []handlers.BulkExportEntry
+}

--- a/cmd/greypot-server/inmemory_repository.go
+++ b/cmd/greypot-server/inmemory_repository.go
@@ -56,7 +56,7 @@ func (ftr *inmemoryTemplateRepository) ListAll() ([]string, error) {
 func (ftr *inmemoryTemplateRepository) LoadTemplate(templateId string) ([]byte, error) {
 	item, found := ftr.files.Get(strings.TrimSpace(templateId))
 	if !found {
-		return nil, fmt.Errorf("template not found in in-mem ory repository")
+		return nil, fmt.Errorf("template not found in in-memory repository")
 	}
 	return item.Content, nil
 }

--- a/cmd/greypot-server/main.go
+++ b/cmd/greypot-server/main.go
@@ -28,12 +28,6 @@ var (
 	disableStudioUI bool = false
 )
 
-type UploadTemplateRequest struct {
-	Name     string
-	Template string
-	Data     any
-}
-
 func init() {
 	flag.StringVar(&templateDir, "templates", "./templates/", "Path to the directory with templates")
 	flag.StringVar(&host, "host", "0.0.0.0", "Host for server")


### PR DESCRIPTION
Users can now specify `Accept: application/zip` and this prompts the server to return a zip file with PDFs instead of returning a JSON with base64 encoded data files.